### PR TITLE
Out of hibernation

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -7,7 +7,7 @@ categories:
     label: 'PR-Internal'
 change-template: '- *$TITLE* by @$AUTHOR - #$NUMBER'
 template: |
-[![Nuget](https://img.shields.io/badge/NuGet-v9.9.9-brightgreen)](https://www.nuget.org/packages/Panner/9.9.9) [![Coverage Status](https://coveralls.io/repos/github/OSDKDev/Panner/badge.svg?branch=refs/tags/v9.9.9)](https://coveralls.io/github/OSDKDev/Panner?branch=refs/tags/v9.9.9)
+[![Nuget](https://img.shields.io/badge/NuGet-v9.9.9-brightgreen)](https://www.nuget.org/packages/Panner/9.9.9) [![Coverage Status](https://coveralls.io/repos/github/IOrlandoni/Panner/badge.svg?branch=refs/tags/v9.9.9)](https://coveralls.io/github/IOrlandoni/Panner?branch=refs/tags/v9.9.9)
 ---
 
 $CHANGES

--- a/.github/workflows/lock-closed-issue.yml
+++ b/.github/workflows/lock-closed-issue.yml
@@ -8,6 +8,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: OSDKDev/lock-issues@v1
+    - uses: IOrlandoni/lock-issues@v1
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/test-and-report.yml
+++ b/.github/workflows/test-and-report.yml
@@ -17,7 +17,9 @@ jobs:
       - name: Check-out
         uses: actions/checkout@master
       - name: Install Dotnet
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.x
       - name: Install ReportGenerator
         run: dotnet tool install dotnet-reportgenerator-globaltool --tool-path tools
       - name: Test

--- a/.github/workflows/unlock-reopened-issue.yml
+++ b/.github/workflows/unlock-reopened-issue.yml
@@ -8,6 +8,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: OSDKDev/unlock-issues@v1
+    - uses: IOrlandoni/unlock-issues@v1
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 [Tt]est[Rr]esults/
 nupkgs/
 /tests/Sort.Tests/coverage.json
+Panner.sln.DotSettings.user
+.idea/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 OSDKDev
+Copyright (c) 2025 IOrlandoni
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <!-- <AspNetCore> -->
 <p align=center><kbd>
-    <b>ASP.NET Core WebAPI?</b> You should start with <a href="https://github.com/OSDKDev/Panner.AspNetCore"><b>Panner.AspNetCore</b></a>!
+    <b>ASP.NET Core WebAPI?</b> You should start with <a href="https://github.com/IOrlandoni/Panner.AspNetCore"><b>Panner.AspNetCore</b></a>!
 </kbd></p>
 <!-- </AspNetCore> -->
 
-# Panner [![Nuget](https://img.shields.io/nuget/v/Panner?label=NuGet&color=success)](https://www.nuget.org/packages/Panner) [![Coverage Status](https://img.shields.io/coveralls/github/OSDKDev/Panner)](https://coveralls.io/github/OSDKDev/Panner?branch=master)
+# Panner [![Nuget](https://img.shields.io/nuget/v/Panner?label=NuGet&color=success)](https://www.nuget.org/packages/Panner) [![Coverage Status](https://img.shields.io/coveralls/github/IOrlandoni/Panner)](https://coveralls.io/github/IOrlandoni/Panner?branch=master)
 **Clean**, **customizable** & **extensible** framework for the configuration, parsing and application of sorts and filters from a CSV.
 
 ---

--- a/src/Panner.csproj
+++ b/src/Panner.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <RootNamespace>Panner</RootNamespace>
     <AssemblyName>Panner</AssemblyName>
-    <Authors>OSDKDev</Authors>
-    <Company>OSDKDev</Company>
+    <Authors>IOrlandoni</Authors>
+    <Company>IOrlandoni</Company>
     <Product>Panner</Product>
-    <RepositoryUrl>https://github.com/OSDKDev/Panner</RepositoryUrl>
-    <PackageProjectUrl>https://github.com/OSDKDev/Panner</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/IOrlandoni/Panner</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/IOrlandoni/Panner</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>logo-flat.png</PackageIcon>
-    <Copyright>Copyright (c) 2019 OSDKDev</Copyright>
+    <Copyright>Copyright (c) 2025 IOrlandoni</Copyright>
     <Description>Clean, customizable and extensible framework for the configuration, parsing and application of sorts and filters from a CSV.</Description>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
 

--- a/tests/Core.Tests/Core.Tests.csproj
+++ b/tests/Core.Tests/Core.Tests.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Filter.Tests/Filter.Tests.csproj
+++ b/tests/Filter.Tests/Filter.Tests.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Sort.Tests/Sort.Tests.csproj
+++ b/tests/Sort.Tests/Sort.Tests.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
- Update target frameworks to `net8.0;net9.0` across projects
- Bump dependencies to latest versions (including test frameworks)
- Update `.gitignore` with editor-specific files
- Replace repository details from `OSDKDev` to `IOrlandoni` (authors, links, and metadata)